### PR TITLE
Improved Delivery Time options

### DIFF
--- a/app/code/community/Quack/GoogleReviews/Helper/Data.php
+++ b/app/code/community/Quack/GoogleReviews/Helper/Data.php
@@ -11,6 +11,8 @@ class Quack_GoogleReviews_Helper_Data extends Mage_Core_Helper_Abstract
     
     const XML_PATH_ESTIMATED_DELIVERY_TIME = 'google/reviews/estimated_delivery_time';
     
+    const XML_PATH_ESTIMATED_DELIVERY_PATTERN = 'google/reviews/estimated_delivery_pattern';
+    
     /**
      * Get Google Merchant account id
      *
@@ -26,6 +28,11 @@ class Quack_GoogleReviews_Helper_Data extends Mage_Core_Helper_Abstract
     {
         return Mage::getStoreConfig(self::XML_PATH_ESTIMATED_DELIVERY_TIME, $store);
     }
+
+    public function getEstimatedDeliveryPattern($store = null)
+    {
+        return Mage::getStoreConfig(self::XML_PATH_ESTIMATED_DELIVERY_PATTERN, $store);
+    }
     
     /**
      * 
@@ -35,14 +42,14 @@ class Quack_GoogleReviews_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getEstimatedDeliveryDate($order)
     {
-        $_pattern = $this->getEstimatedDeliveryTime();
-        $_time = empty($_pattern) ? 0 : $_pattern;
-        if ( !is_numeric($_time) ) {
+        $_time = $this->getEstimatedDeliveryTime();
+        $_pattern = $this->getEstimatedDeliveryPattern();
+        if ( !empty($_pattern) ) {
             if ( preg_match($_pattern, $order->getShippingDescription(), $matches, PREG_OFFSET_CAPTURE) ) {
                 $_time = (int)$matches[1][0];
             }
-            $_time = is_numeric($_time) ? $_time : 0;
         }
+        $_time = is_numeric($_time) ? $_time : 0;
         $_estimatedDate = new DateTime();
         $_estimatedDate->add(new DateInterval("P{$_time}D"));
         return $_estimatedDate->format('Y-m-d');

--- a/app/code/community/Quack/GoogleReviews/etc/config.xml
+++ b/app/code/community/Quack/GoogleReviews/etc/config.xml
@@ -58,7 +58,8 @@
 	    	<reviews>
 	    		<active>1</active>
 	    		<account>1234567</account>
-	    		<estimated_delivery_time>/([0-9]+) days/</estimated_delivery_time>
+	    		<estimated_delivery_time>7</estimated_delivery_time>
+	    		<estimated_delivery_pattern>/([0-9]+) days/</estimated_delivery_pattern>
 	    		<country_code>US</country_code>
 	    	</reviews>
 	    </google>

--- a/app/code/community/Quack/GoogleReviews/etc/system.xml
+++ b/app/code/community/Quack/GoogleReviews/etc/system.xml
@@ -30,13 +30,22 @@
                             <comment>Your Merchant Center ID. You can get this value from the Google Merchant Center.</comment>
                         </account>
                         <estimated_delivery_time translate="label">
-                            <label>Estimated Delivery Time (or pattern)</label>
+                            <label>Estimated Delivery Time</label>
                             <frontend_type>text</frontend_type>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </estimated_delivery_time>
+                        <estimated_delivery_pattern translate="label">
+                            <label>Estimated Delivery Time (Pattern)</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>35</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>Regular Expression to load the delivery time from shipping description. If no matches is found "Estimated Delivery Time" is applied.</comment>
+                        </estimated_delivery_pattern>
                         <country_code translate="label">
                             <label>Country</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
closes #1 

Delivery Time options separated into Time (days) and Pattern (RegExp).
If regular expression not matches Time is used.

Special thanks to @Lach1222