### PR TITLE
Add Customer Reviews Badge - fixes #9

### DIFF
--- a/app/code/community/Quack/GoogleReviews/Block/Badge.php
+++ b/app/code/community/Quack/GoogleReviews/Block/Badge.php
@@ -1,0 +1,29 @@
+<?php
+class Quack_GoogleReviews_Block_Badge extends Mage_Core_Block_Template
+{
+
+    /**
+     * Are both ga and badge available
+     *
+     * @return bool
+     */
+    protected function _isAvailable()
+    {
+        $enabled = Mage::helper('googlereviews')->isGoogleReviewsAvailable();
+        $badgeVisible = Mage::helper('googlereviews')->isGoogleReviewsBadgeVisible();
+        return ($enabled && $badgeVisible);
+    }
+
+    /**
+     * Render GA tracking scripts
+     *
+     * @return string
+     */
+    protected function _toHtml()
+    {
+        if (!$this->_isAvailable()) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/app/code/community/Quack/GoogleReviews/Helper/Data.php
+++ b/app/code/community/Quack/GoogleReviews/Helper/Data.php
@@ -12,6 +12,8 @@ class Quack_GoogleReviews_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_ESTIMATED_DELIVERY_TIME = 'google/reviews/estimated_delivery_time';
     
     const XML_PATH_ESTIMATED_DELIVERY_PATTERN = 'google/reviews/estimated_delivery_pattern';
+
+    const XML_PATH_BADGE_VISIBLE = 'google/reviews/badge';
     
     const XML_PATH_ATTRIBUTE_GTIN = 'google/reviews/attribute_gtin';
     
@@ -65,6 +67,11 @@ class Quack_GoogleReviews_Helper_Data extends Mage_Core_Helper_Abstract
     public function isGoogleReviewsAvailable($store = null)
     {
         return Mage::getStoreConfigFlag(self::XML_PATH_ENABLED, $store);
+    }
+
+    public function isGoogleReviewsBadgeVisible($store = null)
+    {
+        return Mage::getStoreConfigFlag(self::XML_PATH_BADGE_VISIBLE, $store);
     }
     
     /**

--- a/app/code/community/Quack/GoogleReviews/etc/config.xml
+++ b/app/code/community/Quack/GoogleReviews/etc/config.xml
@@ -61,6 +61,7 @@
 	    		<estimated_delivery_time>7</estimated_delivery_time>
 	    		<estimated_delivery_pattern>/([0-9]+) days/</estimated_delivery_pattern>
 	    		<country_code>US</country_code>
+			<badge>1</badge>
 	    		<attribute_gtin>gtin</attribute_gtin>
 	    	</reviews>
 	    </google>

--- a/app/code/community/Quack/GoogleReviews/etc/system.xml
+++ b/app/code/community/Quack/GoogleReviews/etc/system.xml
@@ -28,6 +28,9 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Your Merchant Center ID. You can get this value from the Google Merchant Center.</comment>
+                            <depends>
+                                <active>1</active>
+                            </depends>
                         </account>
                         <estimated_delivery_time translate="label">
                             <label>Estimated Delivery Time</label>
@@ -36,6 +39,9 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <depends>
+                                <active>1</active>
+                            </depends>
                         </estimated_delivery_time>
                         <estimated_delivery_pattern translate="label">
                             <label>Estimated Delivery Time (Pattern)</label>
@@ -45,6 +51,9 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>Regular Expression to load the delivery time from shipping description. If no matches is found "Estimated Delivery Time" is applied.</comment>
+                            <depends>
+                                <active>1</active>
+                            </depends>
                         </estimated_delivery_pattern>
                         <country_code translate="label">
                             <label>Country</label>
@@ -54,15 +63,34 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment>The two-letter country code for the customer's default country (applied only when order address has no country.). This value must be in ISO 3166-1 alpha-2 format. For example, "US".</comment>
+                            <depends>
+                                <active>1</active>
+                            </depends>
                         </country_code>
-                        <attribute_gtin translate="label">
-                            <label>GTIN Attribute</label>
-                            <frontend_type>text</frontend_type>
+                        <badge translate="label">
+                            <label>Enable Google Reviews Badge</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>45</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <comment>Show badge on frontend</comment>
+                            <depends>
+                                <active>1</active>
+                            </depends>
+                        </badge>
+                        <attribute_gtin translate="label">
+                            <label>GTIN Attribute</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
                             <comment>GTIN attribute code for Product Reviews (optional).</comment>
+                            <depends>
+                                <active>1</active>
+                            </depends>
                         </attribute_gtin>
                     </fields>
                 </reviews>

--- a/app/design/frontend/base/default/layout/googlereviews.xml
+++ b/app/design/frontend/base/default/layout/googlereviews.xml
@@ -2,7 +2,10 @@
 <layout version="0.1.0">
     <default>
         <reference name="head" before="-">
-            <block type="googlereviews/gr" name="google_reviews" as="google_reviews" template="googlereviews/gr.phtml" />
+            <block type="googlereviews/gr" name="google_reviews" as="google_reviews" template="googlereviews/gr.phtml"/>
+        </reference>
+        <reference name="footer">
+            <block type="googlereviews/badge" name="google_reviews_badge" as="google_reviews_badge" template="googlereviews/badge.phtml"/>
         </reference>
     </default>
 </layout>

--- a/app/design/frontend/base/default/template/googlereviews/badge.phtml
+++ b/app/design/frontend/base/default/template/googlereviews/badge.phtml
@@ -1,0 +1,14 @@
+<?php
+$_helper = $this->helper('googlereviews');
+$_accountId = $_helper->getAccountId();
+?>
+<script src="https://apis.google.com/js/platform.js?onload=renderBadge" async defer></script>
+<script>
+    window.renderBadge = function() {
+        var ratingBadgeContainer = document.createElement("div");
+        document.body.appendChild(ratingBadgeContainer);
+        window.gapi.load('ratingbadge', function() {
+            window.gapi.ratingbadge.render(ratingBadgeContainer, {"merchant_id": <?php echo $_accountId ?>});
+        });
+    }
+</script>


### PR DESCRIPTION
This commit adds the script that shows the Google Customer Reviews badge on front-end. It will add it in footer.phtml, therefore one may need to add this to one's footer template (not needed by default): 
`<?php echo $this->getChildHtml('google_reviews_badge') ?>`

I think this is what was about in issue #9 (not speaking the language)